### PR TITLE
Rolling back / skip and reformating raw results

### DIFF
--- a/src/main/db/export_formats.ts
+++ b/src/main/db/export_formats.ts
@@ -42,8 +42,8 @@ export class Formats extends Db {
           if (err) resolve(false);
           else {
             for (let i = 0; i < data.length; i += 1) {
-              const pkg: any = {};      
-              pkg.name = data[i].name;         
+              const pkg: any = {};
+              pkg.name = data[i].name;
               pkg.PackageVersion = data[i].version;
               pkg.PackageSPDXIdentifier = data[i].purl;
               pkg.PackageDownloadLocation=data[i].url;
@@ -68,14 +68,14 @@ export class Formats extends Db {
     });
   }
 
-   csv(path: string) {   
+   csv(path: string) {
     return new Promise<boolean>(async (resolve, reject) => {
       try {
         const db = await this.openDb();
         db.all(query.SQL_GET_CSV_DATA, async (err: any, data: any) => {
           db.close();
           if (err) resolve(false);
-          else {                  
+          else {
             const csv = this.csvCreate(data);
             await fs.writeFile(`${path}`, csv, 'utf-8', () => {
               resolve(true);
@@ -98,8 +98,16 @@ export class Formats extends Db {
 
   raw(path: string, results :any) {
     return new Promise<boolean>(async (resolve, reject) => {
+      let out={}
       try {
-          await fs.writeFile(`${path}`, JSON.stringify(results, undefined, 4), 'utf-8', () => {
+
+         for (const [key, obj] of Object.entries(results)) {
+          let vKey = key;
+          if(key.charAt(0)==='/') vKey = key.substring(1)
+        out[vKey]=obj;
+        }
+
+        await fs.writeFile(`${path}`, JSON.stringify(out, undefined, 4), 'utf-8', () => {
           resolve(true);
         });
       } catch (error) {

--- a/src/main/results.ts
+++ b/src/main/results.ts
@@ -17,7 +17,7 @@ ipcMain.handle(IpcEvents.UNIGNORED_FILES, async (event, arg: number[]) => {
 });
 
 ipcMain.handle(IpcEvents.RESULTS_GET, async (event, arg: string) => {
-  if (arg !== null && arg.charAt(0) === '/') arg = arg.substring(1);
+ // if (arg !== null && arg.charAt(0) === '/') arg = arg.substring(1);
   const result = await defaultProject.scans_db.results.getAll(arg);
   if (result)
     return {

--- a/src/main/scannerLib/Winnower/Winnower.js
+++ b/src/main/scannerLib/Winnower/Winnower.js
@@ -300,7 +300,7 @@ export class Winnower extends EventEmitter {
       scanMode = this.#fileList[this.#fileListIndex].scanMode;
     }
 
-    const contentSource = path.replace(`${this.#scanRoot}/`, '');
+    const contentSource = path.replace(`${this.#scanRoot}`, '');
     const content = await fs.promises.readFile(path);
 
     this.#fileListIndex += 1;

--- a/src/main/workspace/ProjectTree.ts
+++ b/src/main/workspace/ProjectTree.ts
@@ -495,7 +495,7 @@ function getLeaf(arbol: any, mypath: string): any {
   if (arbol.type === 'folder') {
     for (j = 0; j < arbol.children.length; j += 1) {
       if (arbol.children[j].type === 'folder' && arbol.children[j].label === res[1]) {
-        const newpath = mypath.replace(`${res[0]}/`, '');
+        const newpath = mypath.replace(`${res[0]}`, '');
         return getLeaf(arbol.children[j], newpath);
       }
       if (arbol.children[j].type === 'file' && arbol.children[j].label === res[1]) {


### PR DESCRIPTION
Skipping leading slash mechanism implemented on previous versions disables the identification of unmatched files.
Slash skipping is done on demmand of exporting raw results