### PR TITLE
remove folder in workspace if project could not be read

### DIFF
--- a/src/main/workspace/workspace.ts
+++ b/src/main/workspace/workspace.ts
@@ -161,7 +161,12 @@ class Workspace extends EventEmitter {
     }
     console.log(`[ WORKSPACE ]: Adding project ${p.getProjectName()} to workspace`);
     const pDirectory = `${this.wsPath}/${p.getProjectName()}`;
-    await fs.promises.mkdir(pDirectory);
+
+    if (!fs.existsSync(`${pDirectory}`)) await fs.promises.mkdir(pDirectory);
+    const files = await fs.promises.readdir(pDirectory);
+    const unlinkPromises = files.map(filename => fs.promises.unlink(`${pDirectory}/${filename}`));
+    await Promise.all(unlinkPromises);
+
     p.setMyPath(pDirectory);
     p.setConfig(this.createProjectCfg());
     await p.save();


### PR DESCRIPTION
- fixed when a project could not be read and a user create a project with the same name