### PR TITLE
feat: SP-921 Add dependency filter on file tree [backend]

### DIFF
--- a/src/main/workspace/tree/File.ts
+++ b/src/main/workspace/tree/File.ts
@@ -1,11 +1,12 @@
 import Node, { NodeStatus } from './Node';
 import { BlackListAbstract } from './blackList/BlackListAbstract';
+import { Visitor } from './visitor/Visitor';
 
 export default class File extends Node {
   private isDependencyFile: boolean;
 
-  constructor(name: string, path: string) {
-    super(name, path);
+  constructor(path: string, name: string) {
+    super(path, name);
     this.type = 'file';
     this.isDependencyFile = false;
     this.isBinaryFile = false;
@@ -54,11 +55,11 @@ export default class File extends Node {
   }
 
   public someNoMatch(): boolean {
-    return (this.original === 'NO-MATCH' && this.getAction() === 'scan');
+    return this.original === 'NO-MATCH' && this.getAction() === 'scan';
   }
 
   public someMatch(): boolean {
-    return (this.original === 'MATCH' && this.getAction() === 'scan');
+    return this.original === 'MATCH' && this.getAction() === 'scan';
   }
 
   public restoreStatus(path: string) {
@@ -143,7 +144,8 @@ export default class File extends Node {
 
   public addDependency(path: string): void {
     if (this.getPath() === path) {
-      if (this.status !== NodeStatus.IDENTIFIED) { // only adds new dependencies
+      if (this.status !== NodeStatus.IDENTIFIED) {
+        // only adds new dependencies
         this.status = NodeStatus.PENDING;
         this.setStatusOnClassnameAs(this.status);
       }
@@ -194,12 +196,13 @@ export default class File extends Node {
     return this.getName() === filename;
   }
 
-  public order():void {
-  }
+  public order(): void {}
 
-  public updateStatusFlags() {
-  }
+  public updateStatusFlags() {}
 
-  public updateFlags() {
+  public updateFlags() {}
+
+  public accept<T>(visitor: Visitor<T>) {
+    return visitor.VisitFile(this);
   }
 }

--- a/src/main/workspace/tree/Folder.ts
+++ b/src/main/workspace/tree/Folder.ts
@@ -1,5 +1,6 @@
 import Node, { NodeStatus } from './Node';
 import { BlackListAbstract } from './blackList/BlackListAbstract';
+import { Visitor } from './visitor/Visitor';
 
 export default class Folder extends Node {
   private children: Node[];
@@ -16,7 +17,7 @@ export default class Folder extends Node {
 
   someFilteredChild: boolean;
 
-  someNoMatchChild :boolean;
+  someNoMatchChild: boolean;
 
   someMatchChild: boolean;
 
@@ -45,12 +46,12 @@ export default class Folder extends Node {
   }
 
   public order(): void {
-    this.children.sort( (a:Node, b:Node)=>{
-      if(a.getType()!=="folder" && b.getType()==="folder") return 1;
-      if(a.getType()==="folder" && b.getType()!=="folder") return -1;
+    this.children.sort((a: Node, b: Node) => {
+      if (a.getType() !== 'folder' && b.getType() === 'folder') return 1;
+      if (a.getType() === 'folder' && b.getType() !== 'folder') return -1;
       return a.getPath().localeCompare(b.getPath());
-    })
-    this.children.forEach((c)=> c.order());
+    });
+    this.children.forEach((c) => c.order());
   }
 
   public addChild(node: Node): void {
@@ -108,45 +109,44 @@ export default class Folder extends Node {
       if (status === NodeStatus.PENDING && !child.isDependency()) this.hasPendingProgress = true;
       if (status === NodeStatus.IGNORED && !child.isDependency()) this.hasIgnoredProgress = true;
       if (
-        this.hasPending &&
-        this.hasIdentified &&
-        this.hasIgnored &&
-        this.hasNoMatch &&
-        this.hasFiltered &&
-        this.hasIdentifiedProgress &&
-        this.hasPendingProgress &&
-        this.hasIgnoredProgress
-      )
-        break;
+        this.hasPending
+        && this.hasIdentified
+        && this.hasIgnored
+        && this.hasNoMatch
+        && this.hasFiltered
+        && this.hasIdentifiedProgress
+        && this.hasPendingProgress
+        && this.hasIgnoredProgress
+      ) break;
     }
   }
 
-public updateFlags() : void {
- for(let i = 0  ; i < this.children.length ; i +=1){
-   const c = this.children[i];
-    c.updateFlags();
-    const someMatch = c.someMatch();
-    const someFiltered = c.someFiltered();
-    const someNoMatch = c.someNoMatch();
-    if(someFiltered) this.someFilteredChild = someFiltered;
-    if(someNoMatch) this.someNoMatchChild = someNoMatch;
-    if(someMatch) this.someMatchChild = someMatch;
+  public updateFlags(): void {
+    for (let i = 0; i < this.children.length; i += 1) {
+      const c = this.children[i];
+      c.updateFlags();
+      const someMatch = c.someMatch();
+      const someFiltered = c.someFiltered();
+      const someNoMatch = c.someNoMatch();
+      if (someFiltered) this.someFilteredChild = someFiltered;
+      if (someNoMatch) this.someNoMatchChild = someNoMatch;
+      if (someMatch) this.someMatchChild = someMatch;
+    }
   }
-}
 
-public someMatch(): boolean {
-  return this.someMatchChild;
-}
+  public someMatch(): boolean {
+    return this.someMatchChild;
+  }
 
-  public someFiltered():boolean{
+  public someFiltered(): boolean {
     return this.someFilteredChild;
   }
 
-  public someNoMatch():boolean{
+  public someNoMatch(): boolean {
     return this.someNoMatchChild;
   }
 
-  public identifiedProgress():boolean {
+  public identifiedProgress(): boolean {
     return this.hasIdentifiedProgress;
   }
 
@@ -322,5 +322,17 @@ public someMatch(): boolean {
       if (child.getName() === filename) return true;
     }
     return false;
+  }
+
+  public accept<T>(visitor: Visitor<T>): T {
+    return visitor.VisitFolder(this);
+  }
+
+  public removeChild(node: Node) {
+    this.children = this.getChildren().filter((child) => child !== node);
+  }
+
+  public isEmpty(): boolean {
+    return this.getChildren().length === 0;
   }
 }

--- a/src/main/workspace/tree/Node.ts
+++ b/src/main/workspace/tree/Node.ts
@@ -1,4 +1,5 @@
 import { BlackListAbstract } from './blackList/BlackListAbstract';
+import { Visitor } from './visitor/Visitor';
 
 export enum NodeStatus {
   FILTERED = 'FILTERED',
@@ -193,4 +194,6 @@ export default abstract class Node {
 
   // Only looks for a specific filename one depth level. WARNING: It does not verify in subfolders!
   public abstract containsFile(filename: string): boolean;
+
+  public abstract accept<T>(visitor: Visitor<T>): T;
 }

--- a/src/main/workspace/tree/treeViewModes/TreeViewFilter.ts
+++ b/src/main/workspace/tree/treeViewModes/TreeViewFilter.ts
@@ -4,7 +4,7 @@ import Node from '../Node';
 import { TreeViewMode } from './TreeViewMode';
 
 export abstract class TreeViewFilter extends TreeViewMode {
-  private filter: any;
+  protected filter: any;
 
   constructor(filter: any) {
     super();

--- a/src/main/workspace/tree/treeViewModes/TreeViewFilterNotPrune.ts
+++ b/src/main/workspace/tree/treeViewModes/TreeViewFilterNotPrune.ts
@@ -1,11 +1,20 @@
 import Node from '../Node';
 import { TreeViewFilter } from './TreeViewFilter';
+import { DependencyHighlighterVisitor } from '../visitor/DependencyHighlighterVisitor';
 
 export class TreeViewFilterNotPrune extends TreeViewFilter {
-  public async getTree(node: Node): Promise<Node>{
+  public async getTree(node: Node): Promise<Node> {
+    // TODO: Adjust all the filters to the visitor pattern.
+    if (this.filter?.usage === 'dependency') {
+      const root = node.getClone();
+      root.accept(new DependencyHighlighterVisitor());
+      return root;
+    }
+
     const files = await this.getFiles();
     const tree = node.getClone();
     tree.filter(files);
+
     return tree;
   }
 }

--- a/src/main/workspace/tree/treeViewModes/TreeViewFilterPrune.ts
+++ b/src/main/workspace/tree/treeViewModes/TreeViewFilterPrune.ts
@@ -1,10 +1,18 @@
-
 import Folder from '../Folder';
 import Node from '../Node';
 import { TreeViewFilter } from './TreeViewFilter';
+import { OnlyKeepDependencyVisitor } from '../visitor/OnlyKeepDependencyVisitor';
 
 export class TreeViewFilterPrune extends TreeViewFilter {
   public async getTree(node: Node): Promise<Node> {
+
+    // TODO: Adjust all the filters to the visitor pattern.
+    if (this.filter?.usage === 'dependency') {
+      const root = node.getClone();
+      root.accept(new OnlyKeepDependencyVisitor());
+      return root;
+    }
+
     const files = await this.getFiles();
     let tree = node.getClonePath(files);
     if (!tree) {

--- a/src/main/workspace/tree/visitor/DependencyHighlighterVisitor.ts
+++ b/src/main/workspace/tree/visitor/DependencyHighlighterVisitor.ts
@@ -1,0 +1,39 @@
+import { Visitor } from './Visitor';
+import Folder from '../Folder';
+import File from '../File';
+import { NodeStatus } from '../Node';
+
+type isHighlighted = boolean;
+
+export class DependencyHighlighterVisitor implements Visitor<isHighlighted> {
+  VisitFile(file: File): isHighlighted {
+    if (!file.isDependency()) {
+      // If the file is not a dependency file, change the status to NOMATCH (it will grey out the icon on the UI)
+      if (file.getStatus() !== NodeStatus.FILTERED) file.setStatus(file.getPath(), NodeStatus.NOMATCH);
+      file.setStatusOnClassnameAs(NodeStatus.NOMATCH);
+      file.setFilteredMatch(false);
+      return false;
+    }
+
+    file.setFilteredMatch(true); // Highlight the dependency file
+    return true;
+  }
+
+  VisitFolder(folder: Folder): isHighlighted {
+    let folderHighlighted: isHighlighted = false;
+
+    const children = folder.getChildren();
+    folder.setFilteredMatch(folderHighlighted);
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (child.accept(this)) folderHighlighted = true; // If any of the children was highlighted, highlight the current node as well
+    }
+
+    folder.setFilteredMatch(folderHighlighted);
+    folder.updateStatusFlags();
+    folder.setStatus(folder.getPath(), folder.getStatusClassName());
+    folder.setStatusOnClassnameAs(folder.getStatus());
+
+    return folderHighlighted;
+  }
+}

--- a/src/main/workspace/tree/visitor/OnlyKeepDependencyVisitor.test.ts
+++ b/src/main/workspace/tree/visitor/OnlyKeepDependencyVisitor.test.ts
@@ -1,0 +1,42 @@
+import { hasDependency, OnlyKeepDependencyVisitor } from './OnlyKeepDependencyVisitor';
+import { Visitor } from './Visitor';
+import Folder from '../Folder';
+import File from '../File';
+
+describe('OnlyKeepDependencyVisitor', () => {
+  let visitor: Visitor<hasDependency>;
+  let root: Folder;
+
+  beforeEach(() => {
+    visitor = new OnlyKeepDependencyVisitor();
+  });
+
+  it('returns folders that contains files with the flag isDependency = true', () => {
+    root = new Folder('/', '');
+
+    const folder1 = new Folder('/src', 'src');
+    const folder2 = new Folder('/src/modules', 'modules');
+    const folder3 = new Folder('/src/modules/user', 'user');
+    const folder4 = new Folder('/src/modules/post', 'post');
+
+    const file1 = new File('/src/modules/user/controller.ts', 'controller.ts');
+    const file2 = new File('/src/modules/post/controller.ts', 'controller.ts');
+    const fileDependency = new File('/package.json', 'package.json');
+    fileDependency.addDependency(fileDependency.getPath()); // Simulates this file is a dependency
+
+    folder1.addChild(folder2);
+    folder2.addChild(folder3);
+    folder2.addChild(folder4);
+
+    folder3.addChild(file1);
+    folder4.addChild(file2);
+
+    root.addChild(folder1);
+    root.addChild(fileDependency);
+
+    root.accept(visitor);
+
+    expect(root.getChildren()).toHaveLength(1);
+    expect(root.getChildren()).toContain(fileDependency);
+  });
+});

--- a/src/main/workspace/tree/visitor/OnlyKeepDependencyVisitor.ts
+++ b/src/main/workspace/tree/visitor/OnlyKeepDependencyVisitor.ts
@@ -1,0 +1,26 @@
+import { Visitor } from './Visitor';
+import Folder from '../Folder';
+import File from '../File';
+
+export type hasDependency = boolean;
+
+export class OnlyKeepDependencyVisitor implements Visitor<hasDependency> {
+  VisitFile(file: File): hasDependency {
+    return file.isDependency();
+  }
+
+  VisitFolder(folder: Folder): hasDependency {
+    const children = folder.getChildren();
+
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (child.accept<hasDependency>(this) === false) {
+        folder.removeChild(child);
+      }
+    }
+
+    // If the current folder is empty, it should be deleted from the parent. return false for that.
+    if (folder.isEmpty()) return false;
+    return true;
+  }
+}

--- a/src/main/workspace/tree/visitor/Visitor.ts
+++ b/src/main/workspace/tree/visitor/Visitor.ts
@@ -1,0 +1,7 @@
+import Folder from '../Folder';
+import File from '../File';
+
+export interface Visitor<T> {
+  VisitFolder(folder: Folder): T;
+  VisitFile(file: File): T;
+}


### PR DESCRIPTION
This PR includes a method `accept` on the Node.ts file, in order to visit the File-tree and change the structure for filtering with "usage: dependency"