### PR TITLE
bug:SP-3667 Clears Monaco editor highlights from previous file matche…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Upcoming changes ...
+### Fixed
+- Fixed Monaco editor decorations not being cleared when switching files
 ### Added
 - Added real-time URL validation with pathname removal and warning message
 - Added migration to remove pathname from API URL from `sbom-workbench-settings.json` file

--- a/src/renderer/features/workbench/components/CodeViewer/CodeViewer.tsx
+++ b/src/renderer/features/workbench/components/CodeViewer/CodeViewer.tsx
@@ -31,6 +31,7 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
   const editor = React.useRef<monaco.editor.IStandaloneCodeEditor>(null);
   const editorContainerRef = React.createRef<HTMLDivElement>();
   const scrollLineDecorations = React.useRef<string[]>([]);
+  const highlightDecorations = React.useRef<string[]>([]);
   const initMonaco = () => {
     const ref = editorContainerRef.current;
     if (ref) {
@@ -116,12 +117,19 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
               ];
             })
             .flat();
-        editor.current.deltaDecorations([], decorations);
+        // Clear previous highlights and add new ones
+        highlightDecorations.current = editor.current.deltaDecorations(
+          highlightDecorations.current,
+          decorations
+        );
 
         editor.current.revealLineNearTop(decorations[0].range.startLineNumber);
       } else {
-        // remove all decorations
-        // editor.current.deltaDecorations([], []);
+        // Clear all decorations when highlight is null or 'all'
+        highlightDecorations.current = editor.current.deltaDecorations(
+          highlightDecorations.current,
+          []
+        );
       }
     }
   };

--- a/src/renderer/features/workbench/pages/detected/pages/Editor/Editor.tsx
+++ b/src/renderer/features/workbench/pages/detected/pages/Editor/Editor.tsx
@@ -43,8 +43,6 @@ const Editor = () => {
 
   const isLoaded = useRef<boolean>(false);
 
-  const highlightParam = useSearchParams().get('highlight');
-
   const dialogCtrl = useContext(DialogContext) as IDialogContext;
 
   const {
@@ -55,7 +53,6 @@ const Editor = () => {
 
   const file = node?.type === 'file' ? node.path : null;
 
-  const highlight =  highlightParam ? SearchUtils.unStemmify(decodeURIComponent(highlightParam)) : null;
   const [matchInfo, setMatchInfo] = useState<any[] | null>(null);
   const [inventories, setInventories] = useState<Inventory[] | null>(null);
   const [inventoriesMatchInfo, setInventoriesMatchInfo] = useState<Result[] | null>(null);
@@ -199,10 +196,10 @@ const Editor = () => {
 
   useEffect(() => {
     if (currentMatch) {
-      const diff = currentMatch?.type !== 'file' && sourceCodePath;
-      setIsDiffView(diff);
+      const enableDiff = (currentMatch?.type == 'snippet' && sourceCodePath !== null);
+      setIsDiffView(enableDiff);
 
-      if (diff || wfp || imported) loadRemoteFile(currentMatch.md5_file);
+      if (enableDiff || wfp || imported) loadRemoteFile(currentMatch.md5_file);
     }
   }, [currentMatch]);
 
@@ -336,7 +333,6 @@ const Editor = () => {
                 language={getExtension(file)}
                 value={localFileContent?.content || ''}
                 highlight={ currentMatch?.lines || null}
-                highlights={highlight || null}
               />
             ) : (
               <div className="file-loader">{localFileContent?.content || t('LoadingLocalFile')}</div>
@@ -362,7 +358,6 @@ const Editor = () => {
                 language={getExtension(file)}
                 value={remoteFileContent.content || ''}
                 highlight={currentMatch.oss_lines || null}
-                highlights={highlight || null}
               />
             ) : (
               <div className="file-loader">


### PR DESCRIPTION
## What's Changed

### Fixed
- Fixed Monaco editor decorations not being cleared when switching files