### PR TITLE
fix(wfp):SP-4346 skip fh2 for binary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [1.39.0] - 2026-04-28
+### Fixed
+- Binary content now skips redundant hash computations for improved performance
+
 ## [1.38.0] - 2026-04-24
 ### Added
 - New option in the project creation settings to unpack **nested archives** (archives inside archives). When enabled, the scanner descends up to 3 levels deep by default; you can adjust the depth from the same setting. Archives nested deeper than the configured limit are skipped and reported in the post-scan dialog.
@@ -238,3 +244,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.37.0]: https://github.com/scanoss/sbom-workbench/compare/v1.36.0...v1.37.0
 [1.37.1]: https://github.com/scanoss/sbom-workbench/compare/v1.37.0...v1.37.1
 [1.38.0]: https://github.com/scanoss/sbom-workbench/compare/v1.37.1...v1.38.0
+[1.39.0]: https://github.com/scanoss/sbom-workbench/compare/v1.38.0...v1.39.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "reflect-metadata": "^0.1.13",
         "regenerator-runtime": "^0.13.5",
         "rimraf": "^6.0.1",
-        "scanoss": "0.39.0",
+        "scanoss": "^0.40.0",
         "sort-paths": "^1.1.1",
         "source-map-support": "^0.5.19",
         "stream-json": "^1.9.1",
@@ -18928,9 +18928,9 @@
       }
     },
     "node_modules/scanoss": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/scanoss/-/scanoss-0.39.0.tgz",
-      "integrity": "sha512-Ql5a1oyuDs72DSh2D5N4UCfa2efFZYK4+cMASNhNw3zQg3CGoY5344q310dLDDGmWQN2SK1KjkGfFaT3AZlVVg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/scanoss/-/scanoss-0.40.0.tgz",
+      "integrity": "sha512-hBBVA/HhIsi7o9+s1AVhjwI2lp6Y5Xaj49NIfX7G+LCa5ssPtxDJeVX80NxwhSlAAK0ubwo5L5UkxjbviAdQUw==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "reflect-metadata": "^0.1.13",
     "regenerator-runtime": "^0.13.5",
     "rimraf": "^6.0.1",
-    "scanoss": "0.39.0",
+    "scanoss": "^0.40.0",
     "sort-paths": "^1.1.1",
     "source-map-support": "^0.5.19",
     "stream-json": "^1.9.1",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "scanoss-workbench",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scanoss-workbench",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "hasInstallScript": true,
       "license": "GPL-2.0-only",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "^9.4.1",
         "flexsearch": "^0.8.151",
-        "scanoss": "0.39.0",
+        "scanoss": "^0.40.0",
         "sqlite3": "^5.1.6"
       }
     },
@@ -2123,9 +2123,9 @@
       }
     },
     "node_modules/scanoss": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/scanoss/-/scanoss-0.39.0.tgz",
-      "integrity": "sha512-Ql5a1oyuDs72DSh2D5N4UCfa2efFZYK4+cMASNhNw3zQg3CGoY5344q310dLDDGmWQN2SK1KjkGfFaT3AZlVVg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/scanoss/-/scanoss-0.40.0.tgz",
+      "integrity": "sha512-hBBVA/HhIsi7o9+s1AVhjwI2lp6Y5Xaj49NIfX7G+LCa5ssPtxDJeVX80NxwhSlAAK0ubwo5L5UkxjbviAdQUw==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.5",
@@ -4136,9 +4136,9 @@
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw=="
     },
     "scanoss": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/scanoss/-/scanoss-0.39.0.tgz",
-      "integrity": "sha512-Ql5a1oyuDs72DSh2D5N4UCfa2efFZYK4+cMASNhNw3zQg3CGoY5344q310dLDDGmWQN2SK1KjkGfFaT3AZlVVg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/scanoss/-/scanoss-0.40.0.tgz",
+      "integrity": "sha512-hBBVA/HhIsi7o9+s1AVhjwI2lp6Y5Xaj49NIfX7G+LCa5ssPtxDJeVX80NxwhSlAAK0ubwo5L5UkxjbviAdQUw==",
       "requires": {
         "@grpc/grpc-js": "^1.5.5",
         "abort-controller": "^3.0.0",

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss-workbench",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "Desktop version to use SCANOSS OSS in your projects",
   "license": "GPL-2.0-only",
   "author": {
@@ -17,7 +17,7 @@
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "^9.4.1",
     "flexsearch": "^0.8.151",
-    "scanoss": "0.39.0",
+    "scanoss": "^0.40.0",
     "sqlite3": "^5.1.6"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 1.39.0

* **Bug Fixes**
  * Improved performance for binary content by eliminating redundant hash computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->