### PR TITLE
fix/SP-4377/eperm-rename-on-smb-shares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.39.1] - 2026-05-12
+### Fixed
+- Fixed crash with "A JavaScript error occurred in the main process" at the end of scans and rescans when the project workspace lives on a network share (UNC/SMB). Transient sharing-violation errors during the final rename of `result.json` (e.g. antivirus scanning the temp file, slow file-handle release on SMB) are now absorbed by an exponential-backoff retry; persistent failures surface as a graceful "Scan Paused" message instead of crashing the main process. Each retry attempt is logged to `project.log` for diagnostics.
+
 ## [1.39.0] - 2026-04-28
 ### Added
 - File viewer now caps loaded files at 250 MB and shows a distinct "File is too large to display" message instead of the generic "File could not be loaded" when the limit is exceeded.
@@ -247,3 +251,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.37.1]: https://github.com/scanoss/sbom-workbench/compare/v1.37.0...v1.37.1
 [1.38.0]: https://github.com/scanoss/sbom-workbench/compare/v1.37.1...v1.38.0
 [1.39.0]: https://github.com/scanoss/sbom-workbench/compare/v1.38.0...v1.39.0
+[1.39.1]: https://github.com/scanoss/sbom-workbench/compare/v1.39.0...v1.39.1

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss-workbench",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "Desktop version to use SCANOSS OSS in your projects",
   "license": "GPL-2.0-only",
   "author": {

--- a/src/__tests__/integration/pipeline-rescan-failures.integration.test.ts
+++ b/src/__tests__/integration/pipeline-rescan-failures.integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment node
+ *
+ * Integration tests for the SP-4377 fix: rescan must survive transient
+ * EPERM/EBUSY/EACCES on fs.rename/unlink (e.g. on Windows SMB shares),
+ * and must surface persistent failures as catchable errors instead of
+ * uncaught exceptions that crash the main process.
+ */
+
+import fs from 'fs';
+import {
+  createTestContext, TestContext, randomFileContent,
+  COMPONENTS, Scanner,
+} from './support/harness';
+
+let ctx: TestContext;
+
+beforeEach(async () => { ctx = await createTestContext(); });
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await ctx.destroy();
+});
+
+const PATH = '/src/main/app.ts';
+
+function fsError(code: string): NodeJS.ErrnoException {
+  const err = new Error(`mock ${code}`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+/**
+ * Spy on fs.promises.rename and inject `failures` consecutive errors with
+ * `code` when the destination ends with `targetSuffix`. Other renames pass
+ * through to the real implementation.
+ */
+function injectRenameFailures(
+  targetSuffix: string,
+  code: string,
+  failures: number,
+) {
+  const realRename = fs.promises.rename.bind(fs.promises);
+  let injected = 0;
+  return jest.spyOn(fs.promises, 'rename').mockImplementation(async (src, dst) => {
+    if (dst.toString().endsWith(targetSuffix) && injected < failures) {
+      injected++;
+      throw fsError(code);
+    }
+    return realRename(src, dst);
+  });
+}
+
+/**
+ * Spy on fs.promises.unlink and inject errors with `code` when the target
+ * ends with `targetSuffix`. If `failures` is Infinity, fails every time.
+ */
+function injectUnlinkFailures(
+  targetSuffix: string,
+  code: string,
+  failures: number,
+) {
+  const realUnlink = fs.promises.unlink.bind(fs.promises);
+  let injected = 0;
+  return jest.spyOn(fs.promises, 'unlink').mockImplementation(async (path) => {
+    if (path.toString().endsWith(targetSuffix) && injected < failures) {
+      injected++;
+      throw fsError(code);
+    }
+    return realUnlink(path);
+  });
+}
+
+describe('scan pipeline — transient fs errors', () => {
+  it('survives 2 transient EBUSY on rename → scan completes', async () => {
+    ctx.writeSourceFiles({ [PATH]: randomFileContent() });
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+
+    // Inject 2 EBUSY failures on the rename of result.json during done().
+    // retryWithBackoff should absorb them and the scan should succeed.
+    const spy = injectRenameFailures('result.json', 'EBUSY', 2);
+
+    const project = ctx.makeProject({ mode: Scanner.ScannerMode.SCAN });
+    const result = await ctx.runPipeline(project);
+
+    expect(result).toBe(true);
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('scan pipeline — persistent fs errors are caught, never uncaught', () => {
+  it('persistent EPERM on rename → pipeline throws (not uncaught crash)', async () => {
+    ctx.writeSourceFiles({ [PATH]: randomFileContent() });
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+
+    injectRenameFailures('result.json', 'EPERM', Infinity);
+
+    const project = ctx.makeProject({ mode: Scanner.ScannerMode.SCAN });
+
+    await expect(ctx.runPipeline(project)).rejects.toMatchObject({ code: 'EPERM' });
+  });
+});
+
+describe('rescan pipeline — transient fs errors', () => {
+  it('survives 2 transient EBUSY on rename → rescan completes', async () => {
+    ctx.writeSourceFiles({ [PATH]: randomFileContent() });
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+    const project = ctx.makeProject({ mode: Scanner.ScannerMode.SCAN });
+    await ctx.runPipeline(project);
+
+    // Now inject 2 EBUSY failures on the next rename of result.json — the
+    // retryWithBackoff should absorb them and the rescan should succeed.
+    const spy = injectRenameFailures('result.json', 'EBUSY', 2);
+
+    project.metadata.getScannerConfig().mode = Scanner.ScannerMode.RESCAN;
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+    const result = await ctx.runPipeline(project);
+
+    expect(result).toBe(true);
+    // 2 injected failures + 1 successful real rename
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('survives 2 transient EACCES on unlink (init) → rescan completes', async () => {
+    ctx.writeSourceFiles({ [PATH]: randomFileContent() });
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+    const project = ctx.makeProject({ mode: Scanner.ScannerMode.SCAN });
+    await ctx.runPipeline(project);
+
+    // RescanTask.init() calls unlink on result.json before re-scanning.
+    // Two transient EACCES should be absorbed by retryWithBackoff.
+    const spy = injectUnlinkFailures('result.json', 'EACCES', 2);
+
+    project.metadata.getScannerConfig().mode = Scanner.ScannerMode.RESCAN;
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+    const result = await ctx.runPipeline(project);
+
+    expect(result).toBe(true);
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('rescan pipeline — persistent fs errors are caught, never uncaught', () => {
+  it('persistent EPERM on rename → pipeline throws (not uncaught crash)', async () => {
+    ctx.writeSourceFiles({ [PATH]: randomFileContent() });
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+    const project = ctx.makeProject({ mode: Scanner.ScannerMode.SCAN });
+    await ctx.runPipeline(project);
+
+    // Persistent EPERM on rename. retryWithBackoff exhausts after 6
+    // attempts and throws — our try/catch surfaces it, ScannerPipeline
+    // logs it and rejects the run promise (no JS-error crash dialog).
+    injectRenameFailures('result.json', 'EPERM', Infinity);
+
+    project.metadata.getScannerConfig().mode = Scanner.ScannerMode.RESCAN;
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+
+    await expect(ctx.runPipeline(project)).rejects.toMatchObject({ code: 'EPERM' });
+  });
+
+  it('persistent EBUSY on unlink (init) → pipeline throws (not uncaught crash)', async () => {
+    ctx.writeSourceFiles({ [PATH]: randomFileContent() });
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+    const project = ctx.makeProject({ mode: Scanner.ScannerMode.SCAN });
+    await ctx.runPipeline(project);
+
+    injectUnlinkFailures('result.json', 'EBUSY', Infinity);
+
+    project.metadata.getScannerConfig().mode = Scanner.ScannerMode.RESCAN;
+    ctx.mockScanResults({ [PATH]: COMPONENTS.sbomWorkbench });
+
+    await expect(ctx.runPipeline(project)).rejects.toMatchObject({ code: 'EBUSY' });
+  });
+});

--- a/src/__tests__/utils/retryWithBackoff.test.ts
+++ b/src/__tests__/utils/retryWithBackoff.test.ts
@@ -1,0 +1,71 @@
+import { retryWithBackoff } from '../../main/utils/utils';
+
+function fsError(code: string): NodeJS.ErrnoException {
+  const err = new Error(`mock ${code}`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+describe('retryWithBackoff', () => {
+  it('resolves on first attempt when op succeeds', async () => {
+    const op = jest.fn().mockResolvedValue('ok');
+    const result = await retryWithBackoff(op, 3, 1);
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on a retryable error and eventually resolves', async () => {
+    const op = jest.fn()
+      .mockRejectedValueOnce(fsError('EPERM'))
+      .mockRejectedValueOnce(fsError('EBUSY'))
+      .mockResolvedValueOnce('ok');
+
+    const result = await retryWithBackoff(op, 5, 1);
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the last error after exhausting attempts', async () => {
+    const op = jest.fn().mockRejectedValue(fsError('EBUSY'));
+    await expect(retryWithBackoff(op, 3, 1)).rejects.toMatchObject({ code: 'EBUSY' });
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws immediately on a non-retryable error without retrying', async () => {
+    const op = jest.fn().mockRejectedValue(fsError('ENOENT'));
+    await expect(retryWithBackoff(op, 5, 1)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors a custom retryableCodes list', async () => {
+    const op = jest.fn()
+      .mockRejectedValueOnce(fsError('ETIMEDOUT'))
+      .mockResolvedValueOnce('ok');
+
+    const result = await retryWithBackoff(op, 3, 1, ['ETIMEDOUT', 'ECONNRESET']);
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a default-retryable code when custom codes exclude it', async () => {
+    const op = jest.fn().mockRejectedValue(fsError('EPERM'));
+    await expect(retryWithBackoff(op, 3, 1, ['ETIMEDOUT'])).rejects.toMatchObject({ code: 'EPERM' });
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits between retries (timing is roughly exponential)', async () => {
+    const op = jest.fn()
+      .mockRejectedValueOnce(fsError('EPERM'))
+      .mockRejectedValueOnce(fsError('EPERM'))
+      .mockResolvedValueOnce('ok');
+
+    const baseDelay = 20;
+    const start = Date.now();
+    await retryWithBackoff(op, 4, baseDelay);
+    const elapsed = Date.now() - start;
+
+    // delays between 3 attempts: 20ms + 40ms = 60ms minimum
+    expect(elapsed).toBeGreaterThanOrEqual(50);
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/main/task/scanner/BaseScannerTask.ts
+++ b/src/main/task/scanner/BaseScannerTask.ts
@@ -21,6 +21,8 @@ import { ImportTask } from '../import/ImportTask';
 import { parser } from 'stream-json';
 import { streamObject } from 'stream-json/streamers/StreamObject.js';
 import  { EOL } from 'os';
+import { retryWithBackoff } from '../../utils/utils';
+import { finished } from 'stream/promises';
 
 
 export abstract class BaseScannerTask<TDispatcher extends IDispatch, TInputScannerAdapter extends IScannerInputAdapter> implements ScannerModule.IPipelineTask {
@@ -129,52 +131,55 @@ export abstract class BaseScannerTask<TDispatcher extends IDispatch, TInputScann
     const resultPath = `${this.project.getMyPath()}/result.json`;
     const tempPath = `${this.project.getMyPath()}/result_temp.json`;
     const writeStream = fs.createWriteStream(tempPath);
-    writeStream.write(`{${EOL}`); // Start JSON object
+    const readStream = fs.createReadStream(resultPath);
 
-    let isFirst = true;
+    // Monitor both streams upfront so errors during the data phase are caught
+    const readStreamSettled = finished(readStream);
+    const writeStreamSettled = finished(writeStream);
 
-    const pipeline = fs.createReadStream(resultPath)
-      .pipe(parser())
-      .pipe(streamObject());
+    try {
+      writeStream.write(`{${EOL}`); // Start JSON object
 
-    pipeline.on('data', ({ key, value }) => {
-      // Modify key to ensure it starts with '/'
-      const modifiedKey = key.startsWith('/') ? key : `/${key}`;
+      let isFirst = true;
+      const pipeline = readStream
+        .pipe(parser())
+        .pipe(streamObject());
 
-      // Write to output file
-      if (!isFirst) {
-        writeStream.write(`,${EOL}`);
-      }
-      isFirst = false;
+      pipeline.on('data', ({ key, value }) => {
+        // Modify key to ensure it starts with '/'
+        const modifiedKey = key.startsWith('/') ? key : `/${key}`;
 
-      writeStream.write(`  "${modifiedKey}": ${JSON.stringify(value)}`);
+        // Write to output file
+        if (!isFirst) {
+          writeStream.write(`,${EOL}`);
+        }
+        isFirst = false;
 
-      // Attach results to project tree
-      this.project.tree.attachResults({ [modifiedKey]: value } );
-    });
+        writeStream.write(`  "${modifiedKey}": ${JSON.stringify(value)}`);
 
-    await new Promise<void>((resolve, reject) => {
-      pipeline.on('end', () => {
-        writeStream.write(`${EOL}}`); // Close JSON object
-        writeStream.end(() => {
-          // Rename temp file to original after write completes
-          fs.renameSync(tempPath, resultPath);
-          log.info('Finished parsing and writing SCANOSS raw results JSON');
-          resolve();
-        });
+        // Attach results to project tree
+        this.project.tree.attachResults({ [modifiedKey]: value } );
       });
 
-      pipeline.on('error', (err) => {
-        writeStream.end();
-        log.error('Error:', err);
-        reject(err);
-      });
+      // Wait for pipeline to finish, or either stream to error first
+      await Promise.race([finished(pipeline), readStreamSettled, writeStreamSettled]);
 
-      writeStream.on('error', (err) => {
-        log.error('Write error:', err);
-        reject(err);
-      });
-    });
+      writeStream.end(`${EOL}}`);
+
+      // Wait for both file descriptors to be released
+      await Promise.all([readStreamSettled, writeStreamSettled]);
+
+      // Rename with retry for transient sharing-violation errors (AV, SMB close lag)
+      await retryWithBackoff(() => fs.promises.rename(tempPath, resultPath));
+      log.info('Finished parsing and writing SCANOSS raw results JSON');
+    } catch (err) {
+      log.error('Error finalizing result.json:', err);
+      readStream.destroy();
+      writeStream.destroy();
+      readStreamSettled.catch(() => undefined);
+      writeStreamSettled.catch(() => undefined);
+      throw err;
+    }
 
     // Import task
     const componentImportTask = new ImportTask(this.project);

--- a/src/main/task/scanner/rescan/RescanTask.ts
+++ b/src/main/task/scanner/rescan/RescanTask.ts
@@ -8,7 +8,8 @@ import { licenseService } from '../../../services/LicenseService';
 import { rescanService, RescanSummary } from '../../../services/RescanService';
 import { IDispatch } from '../dispatcher/IDispatch';
 import { IScannerInputAdapter } from '../adapter/IScannerInputAdapter';
-import { fileExists } from '../../../utils/utils';
+import { fileExists, retryWithBackoff } from '../../../utils/utils';
+import { finished } from 'stream/promises';
 import { utilModel } from '../../../model/UtilModel';
 import { EOL } from 'os';
 import { parser } from 'stream-json';
@@ -34,8 +35,10 @@ export abstract class RescanTask<TDispatcher extends IDispatch, TInputScannerAda
 
   public async init(): Promise<void> {
     log.info('%c[ SCANNER ]: Rescan started ', 'color: green');
-    if (await fileExists(`${this.project.getMyPath()}/result.json`)) await fs.promises.unlink(`${this.project.getMyPath()}/result.json`);
-    if (await fileExists(`${this.project.getMyPath()}/winnowing.wfp`)) await fs.promises.unlink(`${this.project.getMyPath()}/winnowing.wfp`);
+    const resultPath = `${this.project.getMyPath()}/result.json`;
+    const wfpPath = `${this.project.getMyPath()}/winnowing.wfp`;
+    if (await fileExists(resultPath)) await retryWithBackoff(() => fs.promises.unlink(resultPath));
+    if (await fileExists(wfpPath)) await retryWithBackoff(() => fs.promises.unlink(wfpPath));
     await super.init();
   }
 
@@ -51,53 +54,55 @@ export abstract class RescanTask<TDispatcher extends IDispatch, TInputScannerAda
   private async updateResultFile(){
     const resultPath = `${this.project.getMyPath()}/result.json`;
     const tempPath = `${this.project.getMyPath()}/result_temp.json`;
-
     const writeStream = fs.createWriteStream(tempPath);
-    writeStream.write(`{${EOL}`); // Start JSON object
+    const readStream = fs.createReadStream(resultPath);
 
-    let isFirst = true;
+    // Monitor both streams upfront so errors during the data phase are caught
+    const readStreamSettled = finished(readStream);
+    const writeStreamSettled = finished(writeStream);
 
-    const pipeline = fs.createReadStream(resultPath)
-      .pipe(parser())
-      .pipe(streamObject());
+    try {
+      writeStream.write(`{${EOL}`); // Start JSON object
 
-    pipeline.on('data', async ({ key, value }) => {
-      // Modify key to ensure it starts with '/'
-      const modifiedKey = key.startsWith('/') ? key : `/${key}`;
+      let isFirst = true;
+      const pipeline = readStream
+        .pipe(parser())
+        .pipe(streamObject());
 
-      // Write to output file
-      if (!isFirst) {
-        writeStream.write(`,${EOL}`);
-      }
-      isFirst = false;
+      pipeline.on('data', async ({ key, value }) => {
+        // Modify key to ensure it starts with '/'
+        const modifiedKey = key.startsWith('/') ? key : `/${key}`;
 
-      writeStream.write(`  "${modifiedKey}": ${JSON.stringify(value)}`);
+        // Write to output file
+        if (!isFirst) {
+          writeStream.write(`,${EOL}`);
+        }
+        isFirst = false;
 
-      await this.updateStatusFlagsOnFileTree({ [modifiedKey]: value});
-    });
+        writeStream.write(`  "${modifiedKey}": ${JSON.stringify(value)}`);
 
-    await new Promise<void>((resolve, reject) => {
-      pipeline.on('end', () => {
-        writeStream.write(`${EOL}}`); // Close JSON object
-        writeStream.end(() => {
-          // Rename temp file to original after write completes
-          fs.renameSync(tempPath, resultPath);
-          log.info('Finished parsing and writing SCANOSS raw results JSON');
-          resolve();
-        });
+        await this.updateStatusFlagsOnFileTree({ [modifiedKey]: value});
       });
 
-      pipeline.on('error', (err) => {
-        writeStream.end();
-        log.error('Error:', err);
-        reject(err);
-      });
+      // Wait for pipeline to finish, or either stream to error first
+      await Promise.race([finished(pipeline), readStreamSettled, writeStreamSettled]);
 
-      writeStream.on('error', (err) => {
-        log.error('Write error:', err);
-        reject(err);
-      });
-    });
+      writeStream.end(`${EOL}}`);
+
+      // Wait for both file descriptors to be released
+      await Promise.all([readStreamSettled, writeStreamSettled]);
+
+      // Rename with retry for transient sharing-violation errors (AV, SMB close lag)
+      await retryWithBackoff(() => fs.promises.rename(tempPath, resultPath));
+      log.info('Finished parsing and writing SCANOSS raw results JSON');
+    } catch (err) {
+      log.error('Error finalizing result.json:', err);
+      readStream.destroy();
+      writeStream.destroy();
+      readStreamSettled.catch(() => undefined);
+      writeStreamSettled.catch(() => undefined);
+      throw err;
+    }
   }
 
   protected async updateStatusFlagsOnFileTree(results: Record<string, any>){

--- a/src/main/task/scanner/rescan/RescanTask.ts
+++ b/src/main/task/scanner/rescan/RescanTask.ts
@@ -69,7 +69,7 @@ export abstract class RescanTask<TDispatcher extends IDispatch, TInputScannerAda
         .pipe(parser())
         .pipe(streamObject());
 
-      pipeline.on('data', async ({ key, value }) => {
+      pipeline.on('data', ({ key, value }) => {
         // Modify key to ensure it starts with '/'
         const modifiedKey = key.startsWith('/') ? key : `/${key}`;
 
@@ -81,7 +81,7 @@ export abstract class RescanTask<TDispatcher extends IDispatch, TInputScannerAda
 
         writeStream.write(`  "${modifiedKey}": ${JSON.stringify(value)}`);
 
-        await this.updateStatusFlagsOnFileTree({ [modifiedKey]: value});
+        this.updateStatusFlagsOnFileTree({ [modifiedKey]: value });
       });
 
       // Wait for pipeline to finish, or either stream to error first
@@ -105,7 +105,7 @@ export abstract class RescanTask<TDispatcher extends IDispatch, TInputScannerAda
     }
   }
 
-  protected async updateStatusFlagsOnFileTree(results: Record<string, any>){
+  protected updateStatusFlagsOnFileTree(results: Record<string, any>){
     this.project.tree.attachResults(results);
     this.project.tree.updateFlags();
   }

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import log from 'electron-log';
 
 export async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -24,14 +25,21 @@ export async function retryWithBackoff<T>(
   let lastErr: NodeJS.ErrnoException | null = null;
   for (let i = 0; i < attempts; i++) {
     try {
-      return await op();
+      const result = await op();
+      if (i > 0) {
+        log.info(`[retryWithBackoff] succeeded on attempt ${i + 1}/${attempts} (last error: ${lastErr?.code})`);
+      }
+      return result;
     } catch (err) {
       const e = err as NodeJS.ErrnoException;
       lastErr = e;
       if (!retryableCodes.includes(e.code ?? '')) throw e;
       if (i < attempts - 1) {
         const delay = baseDelayMs * 2 ** i;
+        log.warn(`[retryWithBackoff] ${e.code} on attempt ${i + 1}/${attempts}, retrying in ${delay}ms`);
         await new Promise((r) => { setTimeout(r, delay); });
+      } else {
+        log.error(`[retryWithBackoff] exhausted ${attempts} attempts, final error: ${e.code}`);
       }
     }
   }

--- a/src/main/utils/utils.ts
+++ b/src/main/utils/utils.ts
@@ -1,10 +1,9 @@
 import path from 'path';
+import fs from 'fs';
 
-const fs = require('fs').promises;
-
-export async function fileExists(filePath: string):Promise<boolean> {
+export async function fileExists(filePath: string): Promise<boolean> {
   try {
-    await fs.access(filePath, fs.constants.F_OK);
+    await fs.promises.access(filePath, fs.constants.F_OK);
     return true;
   } catch (err) {
     return false;
@@ -13,4 +12,28 @@ export async function fileExists(filePath: string):Promise<boolean> {
 
 export function toPosix(filePath: string): string {
   return filePath.replaceAll(path.sep, path.posix.sep);
+}
+
+// Retries op with exponential backoff on errors whose code is in retryableCodes.
+export async function retryWithBackoff<T>(
+  op: () => Promise<T>,
+  attempts = 6,
+  baseDelayMs = 100,
+  retryableCodes: readonly string[] = ['EPERM', 'EBUSY', 'EACCES'],
+): Promise<T> {
+  let lastErr: NodeJS.ErrnoException | null = null;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await op();
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      lastErr = e;
+      if (!retryableCodes.includes(e.code ?? '')) throw e;
+      if (i < attempts - 1) {
+        const delay = baseDelayMs * 2 ** i;
+        await new Promise((r) => { setTimeout(r, delay); });
+      }
+    }
+  }
+  throw lastErr;
 }


### PR DESCRIPTION
## TL;DR

Scans on SMB shares occasionally crashed Workbench with *"A JavaScript error occurred in the main process"* in the middle of a scan. This PR fixes the crash, adds retry for filesystem operations, and logs each retry so we can diagnose customer reports from `project.log`.

## What was breaking

At the end of every scan/rescan, Workbench rewrites `result.json` via a temp file + rename (to normalize path keys with a leading `/`). On SMB, the rename intermittently failed with `EPERM`. Three things combined:

1. **Our own read stream wasn't fully closed yet.** The OS file handle releases asynchronously after `'end'` fires — on SMB this lag is long enough to block our own `MoveFileEx` (it requires `FILE_SHARE_DELETE`, which our open didn't grant).
2. **No retry on transient errors.** Antivirus scanning the freshly written temp file, SMB close lag, or any external file watcher could hold the destination for a few hundred milliseconds — fatal without a retry.
3. **`fs.renameSync` inside a `writeStream.end()` callback.** A sync `throw` escaping an EventEmitter listener becomes an `uncaughtException`, which **bypasses every `try/catch`** and triggers Electron's crash dialog instead of the friendly "Scan Paused" UI.

## What this PR does

- **Wait for FDs to release before renaming.** Replaces the implicit timing with `await finished(stream)` from `stream/promises`, which resolves on the `'close'` event (after the OS handle is gone). Both read and write streams.
- **Retry on `EPERM` / `EBUSY` / `EACCES`.** New `retryWithBackoff(op)` helper — exponential backoff, 6 attempts (~3s total), code-list overridable. Used at all three problem sites: `BaseScannerTask.done()`, `RescanTask.updateResultFile()`, `RescanTask.init()`.
- **Convert unhandled stream errors into catchable errors.** Both streams are monitored upfront via `finished()`; any `'error'` becomes a promise rejection that flows through normal error handling. No more crashes from this code path.
- **Log every retry to `project.log`.** Format:
  ```
  WARN  [retryWithBackoff] EPERM on attempt 2/6, retrying in 200ms
  INFO  [retryWithBackoff] succeeded on attempt 3/6 (last error: EPERM)
  ```
  Lets us diagnose customer cases: did the retry kick in? Did it succeed? Or did it exhaust?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retry with exponential backoff for transient filesystem errors during scan/rescan, improving robustness against temporary file-access/locking issues.

* **Tests**
  * Added integration and unit tests verifying retry/backoff behavior for transient vs persistent filesystem failures and correct success/failure outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scanoss/sbom-workbench/pull/922)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->