### PR TITLE
Fix/sp 4438 allow empty version latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Importing a `result.json` no longer fails when a result has an empty `version` or `latest` value.
 
 ## [1.39.2] - 2026-05-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Snippet compare view now has a match navigator that re centers both editors on the snippet match, with previous/next controls to step through files that have more than one snippet match.
 ### Fixed
 - Importing a `result.json` no longer fails when a result has an empty `version` or `latest` value.
+- Snippet match highlight in the compare view no longer disappears after scrolling: the match is now marked on the scrollbar, and scrolling one editor keeps the other aligned on its corresponding match.
 
 ## [1.39.2] - 2026-05-13
 ### Fixed

--- a/assets/i18n/en/Common.json
+++ b/assets/i18n/en/Common.json
@@ -23,6 +23,7 @@
   "NoOriginalFilesWith": "No original files found with \"{{searchQuery}}\"",
   "LoadingLocalFile": "Loading local file",
   "LoadingRemoteFile": "Loading remote file",
+  "SnippetMatchCount": "Snippet match <strong>{{current}}</strong> of {{total}}",
   "ProjectImportedCantDisplay": "Imported Project! Local source file not available.",
   "ProjectWFPCantDisplay": "Project created from WFP. Local source file cannot be displayed",
   "AllValidDependenciesAccepted": "All valid pending dependencies will be accepted.",

--- a/assets/i18n/en/Tooltip.json
+++ b/assets/i18n/en/Tooltip.json
@@ -34,6 +34,8 @@
   "SearchForComponentsOnline": "Search for components online",
   "AddNewCustomComponent": "Add new custom component",
   "AddNewVersion": "Add new version",
+  "PreviousMatch": "Previous match",
+  "NextMatch": "Next match",
   "FindInFile": "Find in file",
   "CopyFilePath": "Copy file path",
   "OpenFileInFolder": "Open file in folder",

--- a/assets/i18n/es/Common.json
+++ b/assets/i18n/es/Common.json
@@ -23,6 +23,7 @@
   "NoOriginalFilesWith": "No se encontraron ficheros originales con \"{searchQuery}}\"",
   "LoadingLocalFile": "Cargando fichero local",
   "LoadingRemoteFile": "Cargando fichero remoto",
+  "SnippetMatchCount": "Coincidencia de snippet <strong>{{current}}</strong> de {{total}}",
   "ProjectImportedCantDisplay": "Este proyecto fue importado. El fichero de origen no se puede mostrar.",
   "ProjectWFPCantDisplay": "Este proyecto fue creado desde un WFP. El fichero de origen no se puede mostrar.",
   "AllValidDependenciesAccepted": "Todas las dependencias pendientes válidas serán aceptadas",

--- a/assets/i18n/es/Tooltip.json
+++ b/assets/i18n/es/Tooltip.json
@@ -34,6 +34,8 @@
   "SearchForComponentsOnline": "Buscar componentes en línea",
   "AddNewCustomComponent": "Agregar nuevo componente personalizado",
   "AddNewVersion": "Agregar nueva versión",
+  "PreviousMatch": "Coincidencia anterior",
+  "NextMatch": "Coincidencia siguiente",
   "FindInFile": "Buscar en fichero",
   "CopyFilePath": "Copiar ruta del fichero",
   "OpenFileInFolder": "Abrir fichero en carpeta",

--- a/assets/i18n/fr/Common.json
+++ b/assets/i18n/fr/Common.json
@@ -23,6 +23,7 @@
   "NoOriginalFilesWith": "Aucun fichier développé en interne trouvé contenant \"{{searchQuery}}\"",
   "LoadingLocalFile": "Chargement du fichier local",
   "LoadingRemoteFile": "Chargement du fichier distant",
+  "SnippetMatchCount": "Correspondance de snippet <strong>{{current}}</strong> sur {{total}}",
   "ProjectImportedCantDisplay": "Projet importé ! Le fichier source local n'est pas disponible.",
   "ProjectWFPCantDisplay": "Projet créé depuis WFP. Le fichier source local ne peut pas être affiché",
   "AllValidDependenciesAccepted": "Toutes les dépendances valides en attente seront acceptées.",

--- a/assets/i18n/fr/Tooltip.json
+++ b/assets/i18n/fr/Tooltip.json
@@ -34,6 +34,8 @@
   "SearchForComponentsOnline": "Rechercher des composants en ligne",
   "AddNewCustomComponent": "Ajouter un nouveau composant personnalisé",
   "AddNewVersion": "Ajouter une nouvelle version",
+  "PreviousMatch": "Correspondance précédente",
+  "NextMatch": "Correspondance suivante",
   "FindInFile": "Rechercher dans le fichier",
   "CopyFilePath": "Copier le chemin du fichier",
   "OpenFileInFolder": "Ouvrir le fichier dans le dossier",

--- a/assets/i18n/jp/Common.json
+++ b/assets/i18n/jp/Common.json
@@ -23,6 +23,7 @@
   "NoOriginalFilesWith": "オリジナルファイルなし \"{{searchQuery}}\"",
   "LoadingLocalFile": "ローカルファイルのロード",
   "LoadingRemoteFile": "リモートファイルのロード",
+  "SnippetMatchCount": "スニペットの一致 <strong>{{current}}</strong> / {{total}}",
   "ProjectImportedCantDisplay": "プロジェクトインポート! ローカルソースファイルは存在しません.",
   "ProjectWFPCantDisplay": "WFPからプロジェクトファイル作成. ローカルソースファイルは表示しません",
   "AllValidDependenciesAccepted": "全有効依存物は承認されます.",

--- a/assets/i18n/jp/Tooltip.json
+++ b/assets/i18n/jp/Tooltip.json
@@ -34,6 +34,8 @@
   "SearchForComponentsOnline": "オンラインでコンポーネントを検索",
   "AddNewCustomComponent": "新しいカスタムコンポーネントを追加",
   "AddNewVersion": "新しいバージョンを追加",
+  "PreviousMatch": "前の一致",
+  "NextMatch": "次の一致",
   "FindInFile": "ファイル内を検索",
   "CopyFilePath": "ファイルパスをコピー",
   "OpenFileInFolder": "フォルダ内でファイルを開く",

--- a/assets/i18n/zh/Common.json
+++ b/assets/i18n/zh/Common.json
@@ -23,6 +23,7 @@
   "NoOriginalFilesWith": "找不到自研文件\"{{searchQuery}}\"",
   "LoadingLocalFile": "加载本地文件",
   "LoadingRemoteFile": "加载远程文件",
+  "SnippetMatchCount": "代码片段匹配 第 <strong>{{current}}</strong> 个，共 {{total}} 个",
   "ProjectImportedCantDisplay": "// 该项目已导入。 无法显示源文件。",
   "AllValidDependenciesAccepted": "将接受所有有效的待定依赖项。",
   "AllValidDependenciesAcceptedSubtitle": "那些缺少版本或许可证详细信息的依赖项将不被接受。",

--- a/assets/i18n/zh/Tooltip.json
+++ b/assets/i18n/zh/Tooltip.json
@@ -34,6 +34,8 @@
   "SearchForComponentsOnline": "在线搜索组件",
   "AddNewCustomComponent": "添加新的自定义组件",
   "AddNewVersion": "添加新版本",
+  "PreviousMatch": "上一个匹配",
+  "NextMatch": "下一个匹配",
   "FindInFile": "在文件中查找",
   "CopyFilePath": "复制文件路径",
   "OpenFileInFolder": "打开文件夹中的文件",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scanoss-workbench",
-  "version": "1.39.0",
+  "version": "1.39.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scanoss-workbench",
-      "version": "1.39.0",
+      "version": "1.39.2",
       "hasInstallScript": true,
       "license": "GPL-2.0-only",
       "dependencies": {

--- a/src/__tests__/validator/resultValidator.test.ts
+++ b/src/__tests__/validator/resultValidator.test.ts
@@ -583,5 +583,63 @@ describe('result validator', () => {
     expect(r.isValid).toEqual(true);
   });
 
+  it("valid result, empty 'version' value", async () => {
+    const result = {
+      "backend/app.js": [
+        {
+          "component": "ecommerce-store",
+          "file": "backend/app.js",
+          "file_hash": "39b0d5191c20e23c8360a79a97ecec31",
+          "file_url": "https://api.scanoss.com/file_contents/39b0d5191c20e23c8360a79a97ecec31",
+          "id": "file",
+          "latest": "a8dcdb2",
+          "licenses": [],
+          "lines": "all",
+          "matched": "100%",
+          "oss_lines": "all",
+          "purl": [
+            "pkg:github/hacetheworld/ecommerce-store"
+          ],
+          "source_hash": "39b0d5191c20e23c8360a79a97ecec31",
+          "status": "pending",
+          "vendor": "hacetheworld",
+          "version": ""
+        }
+      ]};
+
+    const resultValidator = new ScanossResultValidator();
+    const r = resultValidator.validate(result);
+    expect(r.isValid).toEqual(true);
+  });
+
+  it("valid result, empty 'latest' value", async () => {
+    const result = {
+      "backend/app.js": [
+        {
+          "component": "ecommerce-store",
+          "file": "backend/app.js",
+          "file_hash": "39b0d5191c20e23c8360a79a97ecec31",
+          "file_url": "https://api.scanoss.com/file_contents/39b0d5191c20e23c8360a79a97ecec31",
+          "id": "file",
+          "latest": "",
+          "licenses": [],
+          "lines": "all",
+          "matched": "100%",
+          "oss_lines": "all",
+          "purl": [
+            "pkg:github/hacetheworld/ecommerce-store"
+          ],
+          "source_hash": "39b0d5191c20e23c8360a79a97ecec31",
+          "status": "pending",
+          "vendor": "hacetheworld",
+          "version": "a8dcdb2"
+        }
+      ]};
+
+    const resultValidator = new ScanossResultValidator();
+    const r = resultValidator.validate(result);
+    expect(r.isValid).toEqual(true);
+  });
+
 
 });

--- a/src/main/modules/validator/ScanossResultValidator.ts
+++ b/src/main/modules/validator/ScanossResultValidator.ts
@@ -109,19 +109,29 @@ export class ScanossResultValidator {
       'file_hash': result.file_hash,
       'file_url': result.file_url,
       'id': result.id,
-      'latest': result.latest,
       'lines': result.lines,
       'matched': result.matched,
       'oss_lines': result.oss_lines,
       'source_hash': result.source_hash,
       'status': result.status,
       'vendor': result.vendor,
-      'version': result.version,
     };
 
     for (const [field, value] of Object.entries(requiredStrings)) {
       if (!value || typeof value !== 'string') {
         this.addError(`${prefix}`, `required '${field}' field must be provided`, value);
+      }
+    }
+
+    // Fields that must exist and be strings, but are allowed to be empty
+    const optionalStrings = {
+      'latest': result.latest,
+      'version': result.version,
+    };
+
+    for (const [field, value] of Object.entries(optionalStrings)) {
+      if (typeof value !== 'string') {
+        this.addError(`${prefix}`, `required '${field}' field must be a string`, value);
       }
     }
 

--- a/src/renderer/features/workbench/components/CodeViewer/CodeViewer.tsx
+++ b/src/renderer/features/workbench/components/CodeViewer/CodeViewer.tsx
@@ -2,6 +2,26 @@ import React, { useEffect } from 'react';
 import * as monaco from 'monaco-editor';
 import CodeViewerManagerInstance from '../../pages/detected/pages/Editor/CodeViewerManager';
 
+// Shared across the synced editor pair so the scroll one editor applies to the
+// other doesn't bounce back and drift. A single flag is enough: only one diff
+// pair is ever active at a time.
+let isSyncingScroll = false;
+
+// Reveal a line on each editor of a synced pair at once, without the scroll-sync
+// dragging one editor off the line we just placed the other on. Lets an outside
+// control (e.g. the match navigator) re-align both panes on a match.
+export const revealLinesAligned = (targets: Array<{ id: string; line: number }>) => {
+  isSyncingScroll = true;
+  targets.forEach(({ id, line }) => {
+    CodeViewerManagerInstance.get(id)?.revealLineNearTop(line);
+  });
+  // The programmatic scroll may settle on the next frame; keep sync suppressed
+  // until then so it doesn't reach the synced editor's handler.
+  requestAnimationFrame(() => {
+    isSyncingScroll = false;
+  });
+};
+
 export interface HighLighted {
   match: string;
   count: number;
@@ -34,7 +54,21 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
   const scrollLineDecorations = React.useRef<string[]>([]);
   const highlightDecorations = React.useRef<string[]>([]);
   const scrollDisposable = React.useRef<monaco.IDisposable>(null);
-  const isSyncingScroll = React.useRef(false);
+  const suppressScrollSync = React.useRef(false);
+  const lastScrollTop = React.useRef(0);
+
+  // Run a programmatic scroll (reveal, model reset) without propagating it to the
+  // synced editor, so each editor can reveal its own match without overriding the other.
+  const withoutScrollSync = (fn: () => void) => {
+    suppressScrollSync.current = true;
+    fn();
+    // The scroll event from a programmatic change may fire on the next frame; keep
+    // sync suppressed until then so it doesn't reach the synced editor's handler.
+    requestAnimationFrame(() => {
+      suppressScrollSync.current = false;
+    });
+  };
+
   const initMonaco = () => {
     const ref = editorContainerRef.current;
     if (ref) {
@@ -115,7 +149,7 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
       if (model) model.dispose();
 
       const nModel = monaco.editor.createModel(value, language);
-      mEditor.setModel(nModel);
+      withoutScrollSync(() => mEditor.setModel(nModel));
       // mEditor.focus();
       // mEditor.layout({} as monaco.editor.IDimension);
     }
@@ -148,7 +182,12 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
                     isWholeLine: true,
                     className: 'lineHighlightDecoration',
                     linesDecorationsClassName: 'lineRangeDecoration',
-
+                    // Keep the match location visible on the scrollbar so it can still
+                    // be found (and clicked to jump back) after scrolling away.
+                    overviewRuler: {
+                      color: 'rgba(58, 91, 185, 0.8)',
+                      position: monaco.editor.OverviewRulerLane.Full,
+                    },
                   },
                 },
               ];
@@ -160,7 +199,7 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
           decorations
         );
 
-        editor.current.revealLineNearTop(decorations[0].range.startLineNumber);
+        withoutScrollSync(() => editor.current.revealLineNearTop(decorations[0].range.startLineNumber));
       } else {
         // Clear all decorations when highlight is null or 'all'
         highlightDecorations.current = editor.current.deltaDecorations(
@@ -242,7 +281,7 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
       mEditor.deltaDecorations([], matches);
 
       if (matches.length > 0) {
-        mEditor.revealRangeNearTop(matches[0].range);
+        withoutScrollSync(() => mEditor.revealRangeNearTop(matches[0].range));
       }
 
       // Call the callback with the matched terms
@@ -269,13 +308,20 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
     }
 
     if (syncScrollWith && editor.current) {
+      lastScrollTop.current = editor.current.getScrollTop();
       scrollDisposable.current = editor.current.onDidScrollChange((e) => {
-        if (isSyncingScroll.current) return;
+        // Track the delta so we always know how far this editor moved, even while
+        // a programmatic reveal keeps lastScrollTop up to date for the next user scroll.
+        const delta = e.scrollTop - lastScrollTop.current;
+        lastScrollTop.current = e.scrollTop;
+        if (isSyncingScroll || suppressScrollSync.current || delta === 0) return;
         const target = CodeViewerManagerInstance.get(syncScrollWith);
         if (target) {
-          isSyncingScroll.current = true;
-          target.setScrollTop(e.scrollTop);
-          isSyncingScroll.current = false;
+          isSyncingScroll = true;
+          // Move the other editor by the same delta instead of to the same absolute
+          // position, so each side stays aligned on its own match after scrolling.
+          target.setScrollTop(target.getScrollTop() + delta);
+          isSyncingScroll = false;
         }
       });
     }
@@ -323,8 +369,10 @@ const CodeViewer = ({ id, value, language, highlight, highlights, highlightMatch
         }]
       );
 
-      editor.current.revealLineNearTop(scrollToLine);
-      editor.current.setPosition({ lineNumber: scrollToLine, column: 1 });
+      withoutScrollSync(() => {
+        editor.current.revealLineNearTop(scrollToLine);
+        editor.current.setPosition({ lineNumber: scrollToLine, column: 1 });
+      });
       editor.current.focus();
     }
   }, [scrollToLine]);

--- a/src/renderer/features/workbench/pages/detected/pages/Editor/Editor.scss
+++ b/src/renderer/features/workbench/pages/detected/pages/Editor/Editor.scss
@@ -63,6 +63,60 @@
   grid-gap: 10px;
 }
 
+.match-nav {
+  display: flex;
+  align-items: stretch;
+  width: fit-content;
+  margin: 18px -1px -6px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 1px 0 2px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.12);
+  color: var(--color-font);
+  position: relative;
+  z-index: 10;
+
+  .MuiIconButton-root {
+    color: var(--text-color-primary);
+    padding: 4px 8px;
+    border-radius: 0;
+
+    i {
+      font-size: 16px;
+      line-height: 1;
+    }
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    &.Mui-disabled {
+      color: $ignored-gray;
+    }
+  }
+
+  .match-nav-center {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 12px;
+    border-left: 1px solid rgba(0, 0, 0, 0.1);
+    border-right: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
+  .match-nav-label {
+    font-size: 12px;
+    line-height: 1;
+    color: var(--color-font);
+    white-space: nowrap;
+
+    strong {
+      font-weight: 700;
+    }
+  }
+}
+
 .editors {
   display: grid;
   overflow-y: visible !important;

--- a/src/renderer/features/workbench/pages/detected/pages/Editor/Editor.tsx
+++ b/src/renderer/features/workbench/pages/detected/pages/Editor/Editor.tsx
@@ -18,13 +18,14 @@ import { selectNavigationState } from '@store/navigation-store/navigationSlice';
 import * as FileUtils from '@shared/utils/file-utils';
 import * as SearchUtils from '@shared/utils/search-utils';
 import useSearchParams from '@hooks/useSearchParams';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { selectWorkspaceState } from '@store/workspace-store/workspaceSlice';
 import Breadcrumb from '../../../../components/Breadcrumb/Breadcrumb';
 import MatchInfoCard, { MATCH_INFO_CARD_ACTIONS } from '../../../../components/MatchInfoCard/MatchInfoCard';
 import FileToolbar, { ToolbarActions } from '../../../../components/FileToolbar/FileToolbar';
 import { workbenchController } from '../../../../../../controllers/workbench-controller';
-import CodeViewer from '../../../../components/CodeViewer/CodeViewer';
+import { IconButton } from '@mui/material';
+import CodeViewer, { revealLinesAligned } from '../../../../components/CodeViewer/CodeViewer';
 import { CodeViewerManager } from './CodeViewerManager';
 import NoMatchFound from '../../../../components/NoMatchFound/NoMatchFound';
 
@@ -63,6 +64,30 @@ const Editor = () => {
   const [currentMatch, setCurrentMatch] = useState<Record<string, any> | null>(null);
   const [remoteFileContent, setRemoteFileContent] = useState<FileContent | null>(null);
   const [isDiffView, setIsDiffView] = useState<boolean>(false);
+  const [matchRangeIndex, setMatchRangeIndex] = useState<number>(0);
+
+  // Start line of each highlighted range, e.g. "98-121,140-150" -> [98, 140].
+  const parseRangeStarts = (ranges?: string | null): number[] =>
+    (ranges || '')
+      .split(',')
+      .map((range) => parseInt(range.split('-')[0], 10))
+      .filter((n) => !Number.isNaN(n));
+
+  const localMatchStarts = parseRangeStarts(currentMatch?.lines);
+  const remoteMatchStarts = parseRangeStarts(currentMatch?.oss_lines);
+
+  // Re-align both editors on a match range, regardless of how far either was scrolled.
+  const goToMatch = (index: number) => {
+    if (localMatchStarts.length === 0) return;
+    const i = Math.min(Math.max(index, 0), localMatchStarts.length - 1);
+    setMatchRangeIndex(i);
+
+    const targets = [{ id: CodeViewerManager.LEFT, line: localMatchStarts[i] }];
+    if (isDiffView) {
+      targets.push({ id: CodeViewerManager.RIGHT, line: remoteMatchStarts[i] ?? localMatchStarts[i] });
+    }
+    revealLinesAligned(targets);
+  };
 
   const init = async () => {
     setMatchInfo(null);
@@ -202,6 +227,10 @@ const Editor = () => {
   }, [matchInfo]);
 
   useEffect(() => {
+    setMatchRangeIndex(0);
+  }, [currentMatch]);
+
+  useEffect(() => {
     if (currentMatch) {
       const enableDiff = (currentMatch?.type == 'snippet' && sourceCodePath !== null);
       setIsDiffView(enableDiff);
@@ -320,6 +349,38 @@ const Editor = () => {
                 && matchInfo?.length === 0 && <NoMatchFound identifyHandler={onNoMatchIdentifyPressed} showLabel />
             )}
           </div>
+
+          {isDiffView && currentMatch && localMatchStarts.length > 0 && (
+            <div className="match-nav">
+              <IconButton
+                size="small"
+                disableRipple
+                title={t('Tooltip:PreviousMatch')}
+                disabled={matchRangeIndex <= 0}
+                onClick={() => goToMatch(matchRangeIndex - 1)}
+              >
+                <i className="ri-arrow-up-s-line" />
+              </IconButton>
+              <span className="match-nav-center">
+                <span className="match-nav-label">
+                  <Trans
+                    i18nKey="Common:SnippetMatchCount"
+                    components={{ strong: <strong /> }}
+                    values={{ current: matchRangeIndex + 1, total: localMatchStarts.length }}
+                  />
+                </span>
+              </span>
+              <IconButton
+                size="small"
+                disableRipple
+                title={t('Tooltip:NextMatch')}
+                disabled={localMatchStarts.length > 1 && matchRangeIndex >= localMatchStarts.length - 1}
+                onClick={() => goToMatch(matchRangeIndex + 1)}
+              >
+                <i className="ri-arrow-down-s-line" />
+              </IconButton>
+            </div>
+          )}
         </header>
       </header>
 


### PR DESCRIPTION

<img width="1014" height="415" alt="image" src="https://github.com/user-attachments/assets/f633c6bc-d1e0-4042-bd3e-13d73b7c98b9" />
<img width="1014" height="415" alt="image" src="https://github.com/user-attachments/assets/a4be0e2a-92ab-4854-8133-7ad56c3e260e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Match navigator in compare view with previous/next controls and a visible match count that recenters both editors on the current snippet match.

* **Bug Fixes**
  * Persistent snippet highlighting after scrolling fixed.
  * Import errors when version/latest are empty strings resolved.

* **Localization**
  * Added translations for match navigation labels and match-count text (EN/ES/FR/JP/ZH).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->