### PR TITLE
fix(export):SP-4447 include identified no-match/filtered files in CSV…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.40.1] - 2026-06-10
+### Fixed
+- Files with **no-match** or **filtered** status that were manually identified are now included in the CSV report.
+
 ## [1.40.0] - 2026-06-09
 ### Added
 - The inventory **usage** options are now a configurable catalog. It ships with non-deletable defaults (file, snippet, pre-requisite, Dynamic library, Original code, Separate work, Other (Development tool)) and lets you create your own usages on the fly from the identify dialog and delete custom ones. Custom usages are saved in the workspace settings and shared across projects.
@@ -268,3 +272,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.39.1]: https://github.com/scanoss/sbom-workbench/compare/v1.39.0...v1.39.1
 [1.39.2]: https://github.com/scanoss/sbom-workbench/compare/v1.39.1...v1.39.2
 [1.40.0]: https://github.com/scanoss/sbom-workbench/compare/v1.39.2...v1.40.0
+[1.40.1]: https://github.com/scanoss/sbom-workbench/compare/v1.40.0...v1.40.1

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss-workbench",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "description": "Desktop version to use SCANOSS OSS in your projects",
   "license": "GPL-2.0-only",
   "author": {

--- a/src/__tests__/export/CSV/sbom-csv.test.ts
+++ b/src/__tests__/export/CSV/sbom-csv.test.ts
@@ -105,6 +105,17 @@ describe('SBOM CSV Tests', () => {
     expect(row6[colIndex.detected_license]).toBe('BSD-2-Clause AND GPL-2.0-only');
     expect(row6[colIndex.concluded_license]).toBe('GPL-2.0-only');
     expect(row6[colIndex.comment]).toBe('inventory 3');
+
+    // A manually identified file with no scan match (no-match/filtered) has empty detected
+    // fields but must still appear in the identified report.
+    const noMatchRow = lines
+      .map((line) => line.split(',').map((column) => column.trim()))
+      .find((columns) => columns[colIndex.path] === '/src/no_match_identified.c');
+    expect(noMatchRow).toBeDefined();
+    expect(noMatchRow[colIndex.detected_purl]).toBe('');
+    expect(noMatchRow[colIndex.concluded_purl]).toBe('pkg:github/scanoss/scanner.c');
+    expect(noMatchRow[colIndex.concluded_version]).toBe('v1.3.3');
+    expect(noMatchRow[colIndex.concluded_license]).toBe('GPL-2.0-only');
   });
 
   it('SBOM CSV detected export test', async () => {

--- a/src/__tests__/export/ExportRepositoryMock.ts
+++ b/src/__tests__/export/ExportRepositoryMock.ts
@@ -105,6 +105,19 @@ export class ExportRepositoryMock implements ExportRepository {
         url_hash: '7f25711ba80970b0de14230872becfc8',
         download_url: 'https://github.com/gentoo/gentoo/archive/53bd330.zip',
       },
+      {
+        // Manually identified file with no scan match (no-match/filtered): no detected license,
+        // only a concluded license. Must still appear as a package in the SBOM.
+        component: 'scanner.c',
+        purl: 'pkg:github/scanoss/scanner.c',
+        version: 'v1.3.3',
+        vendor: null,
+        detected_licenses: '',
+        concluded_licenses: 'GPL-2.0-only',
+        url: 'https://github.com/scanoss/scanner.c',
+        url_hash: null,
+        download_url: null,
+      },
     ]);
   }
 
@@ -585,6 +598,25 @@ export class ExportRepositoryMock implements ExportRepository {
         detected_url: '',
         concluded_url: '',
         comment: '',
+      },
+      {
+        // Manually identified file with no scan match (no-match/filtered): no detected fields,
+        // only concluded fields are populated.
+        inventory_id: 7,
+        path: '/src/no_match_identified.c',
+        usage: 'file',
+        detected_component: '',
+        concluded_component: 'scanner.c',
+        detected_purl: '',
+        concluded_purl: 'pkg:github/scanoss/scanner.c',
+        detected_version: '',
+        concluded_version: 'v1.3.3',
+        latest_version: '',
+        detected_license: '',
+        concluded_license: 'GPL-2.0-only',
+        detected_url: '',
+        concluded_url: 'https://github.com/scanoss/scanner.c',
+        comment: 'manually identified no-match file',
       },
     ]);
   }

--- a/src/__tests__/export/SPDXLite/spdx.test.ts
+++ b/src/__tests__/export/SPDXLite/spdx.test.ts
@@ -95,10 +95,17 @@ describe('SPDX Lite tests', () => {
     expect(spdxLite.creationInfo.creators[0].includes(`Tool: ${AppConfig.APP_NAME}`)).toBe(true);
     expect(spdxLite.creationInfo.creators[2]).toEqual(`Organization: ${AppConfig.ORGANIZATION_NAME}`);
     expect(spdxLite.creationInfo.comment).toEqual('SBOM Build information - SBOM Type: Build');
-    expect(spdxLite.documentDescribes.length).toEqual(2);
+    expect(spdxLite.documentDescribes.length).toEqual(3);
 
     expect(spdxLite.packages[0].versionInfo).toEqual('1.2.0');
     expect(spdxLite.packages[1].licenseConcluded).toEqual('Beerware');
+
+    // A manually identified file with no scan match (no-match/filtered) still appears as a
+    // package: its declared (detected) license is NOASSERTION but the concluded license is kept.
+    expect(spdxLite.packages[2].name).toEqual('pkg:github/scanoss/scanner.c');
+    expect(spdxLite.packages[2].versionInfo).toEqual('v1.3.3');
+    expect(spdxLite.packages[2].licenseDeclared).toEqual('NOASSERTION');
+    expect(spdxLite.packages[2].licenseConcluded).toEqual('GPL-2.0-only');
 
     // check if right download location is set when no download location is coming from the engine
     expect(spdxLite.packages[0].downloadLocation).toEqual('https://github.com/gentoo/gentoo');

--- a/src/__tests__/export/cycloneDX/cyclonedx.test.ts
+++ b/src/__tests__/export/cycloneDX/cyclonedx.test.ts
@@ -1,0 +1,59 @@
+import { ExportRepositoryMock } from '../ExportRepositoryMock';
+import { CycloneDXIdentified } from '../../../main/modules/export/format/CycloneDX/CycloneDXIdentified';
+import { CycloneDXDetected } from '../../../main/modules/export/format/CycloneDX/CycloneDXDetected';
+import { Project } from '../../../main/workspace/Project';
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: jest.fn(() => '/mock/path'),
+    getName: jest.fn(() => 'MockAppName'),
+    getVersion: jest.fn(() => '1.0.0'),
+    isPackaged: false,
+  },
+  ipcMain: {
+    on: jest.fn(),
+    send: jest.fn(),
+  },
+}));
+
+jest.mock('electron-log', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}));
+
+describe('CycloneDX tests', () => {
+  let exportRepositoryMock: ExportRepositoryMock;
+  beforeEach(() => {
+    exportRepositoryMock = new ExportRepositoryMock();
+  });
+
+  it('CycloneDX identified test', async () => {
+    const formatter = new CycloneDXIdentified(new Project('test project'), exportRepositoryMock);
+    const { report } = await formatter.generate();
+    const bom = JSON.parse(report);
+
+    const purls = bom.components.map((c) => c.purl);
+
+    // A manually identified file with no scan match (no-match/filtered) still appears as a
+    // component, keyed by its concluded PURL.
+    const noMatch = bom.components.find((c) => c.purl === 'pkg:github/scanoss/scanner.c');
+    expect(noMatch).toBeDefined();
+    expect(noMatch.version).toEqual('v1.3.3');
+    expect(noMatch.licenses.some((l) => l.license?.id === 'GPL-2.0-only')).toBe(true);
+
+    // The detected components are also present.
+    expect(purls).toContain('pkg:github/gentoo/gentoo');
+  });
+
+  it('CycloneDX detected test', async () => {
+    const formatter = new CycloneDXDetected(new Project('test project'), exportRepositoryMock);
+    const { report } = await formatter.generate();
+    const bom = JSON.parse(report);
+
+    const purls = bom.components.map((c) => c.purl);
+    expect(purls).toContain('pkg:github/gentoo/gentoo');
+    expect(purls).toContain('pkg:github/ibm-openbmc/openbmc');
+  });
+});

--- a/src/main/model/querys_db.ts
+++ b/src/main/model/querys_db.ts
@@ -853,7 +853,7 @@ FROM files f LEFT JOIN results r ON (r.fileId=f.fileId) #FILTER ;`;
   INNER JOIN file_inventories fi ON i.id = fi.inventoryid
   INNER JOIN files f ON f.fileId = fi.fileId
   INNER JOIN component_versions cv ON cv.id = i.cvid
-  INNER JOIN results r ON f.fileId = r.fileId
+  LEFT JOIN results r ON f.fileId = r.fileId
   UNION
   SELECT i.id as inventory_id,
          f.path,

--- a/src/main/modules/export/format/CSV/SBOM-csv.ts
+++ b/src/main/modules/export/format/CSV/SBOM-csv.ts
@@ -80,16 +80,21 @@ export class SBOMCsv extends Format {
       const validDetectedPurl = isValidPurl(comp.detected_purl);
       const validConcludedPurl = isValidPurl(comp.concluded_purl);
 
-      if (!validDetectedPurl && comp.detected_purl !== '') {
+      if (!validDetectedPurl && comp.detected_purl) {
         invalidPurls.add(comp.detected_purl);
       }
 
-      if (!validConcludedPurl && comp.concluded_purl !== '') {
+      if (!validConcludedPurl && comp.concluded_purl) {
         invalidPurls.add(comp.concluded_purl);
       }
 
-      // Not evaluate validConcludedPurl condition on detected report
-      if (validDetectedPurl && (validConcludedPurl || this.source === ExportSource.DETECTED)) {
+      // Detected reports require a valid detected PURL. Identified reports require a valid
+      // concluded PURL; the detected PURL may be empty for files with no scan match
+      // (no-match/filtered) that were manually identified.
+      const include = this.source === ExportSource.DETECTED
+        ? validDetectedPurl
+        : validConcludedPurl && (validDetectedPurl || !comp.detected_purl);
+      if (include) {
         reportData.push(comp);
       }
     });


### PR DESCRIPTION
… report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where manually identified files with no-match or filtered status were excluded from CSV export reports. These files now appear in the exported identified report with their complete identification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->